### PR TITLE
Only use SSL when a HTTPS URL is passed through

### DIFF
--- a/lib/devicedb_comms/shared.rb
+++ b/lib/devicedb_comms/shared.rb
@@ -10,7 +10,7 @@ module DeviceDBComms
 
       if pem_path
         pem = File.read(pem_path)
-        @http.use_ssl = true
+        @http.use_ssl = true if uri.scheme == 'https'
         @http.cert = OpenSSL::X509::Certificate.new(pem)
         @http.key = OpenSSL::PKey::RSA.new(pem)
         @http.verify_mode = OpenSSL::SSL::VERIFY_NONE


### PR DESCRIPTION
This appears to be the only place in the whole hive stack that is forcing you to use SSL - Hive Daemons won't connect without it.
